### PR TITLE
feature: 分页查询（视频列表、关注列表、粉丝列表、点赞列表）

### DIFF
--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/config/MyBatisPlusConfig.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/config/MyBatisPlusConfig.java
@@ -1,0 +1,17 @@
+package org.zjudevelop.playerbackbend.config;
+
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MyBatisPlusConfig {
+
+    @Bean
+    public MybatisPlusInterceptor mybatisPlusInterceptor () {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor());
+        return interceptor;
+    }
+}

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/controller/UserController.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/controller/UserController.java
@@ -17,6 +17,7 @@ import org.zjudevelop.playerbackbend.dto.*;
 import org.zjudevelop.playerbackbend.pojo.CheckAuth;
 import org.zjudevelop.playerbackbend.pojo.JwtProperties;
 import org.zjudevelop.playerbackbend.domain.User;
+import org.zjudevelop.playerbackbend.utils.PageResult;
 import org.zjudevelop.playerbackbend.pojo.QNDataServer;
 import org.zjudevelop.playerbackbend.service.UploadService;
 import org.zjudevelop.playerbackbend.service.UserService;
@@ -201,33 +202,23 @@ public class UserController {
     /**
      * 查询粉丝列表
      * */
-    @GetMapping("/follows/follower/{id}")
-    @ApiOperation("查询粉丝列表")
+    @GetMapping("/follows/follower")
+    @ApiOperation("分页查询给定id的粉丝列表")
     @CheckAuth(check = false)
-    public RestResult<FollowersDTO> getFollowers(@ApiParam("查询用户id") @PathVariable Long id) {
-        List<Follows> followsList = userService.getFollowers(id);
-        List<Long> follwersList = followsList.stream().map(Follows::getFollowerId).collect(Collectors.toList());
-        FollowersDTO followersDTO = new FollowersDTO().builder()
-                .id(id)
-                .followerIds(follwersList)
-                .build();
-        return RestResult.success(followersDTO);
+    public RestResult<PageResult> getFollowers(FollowersPageQueryDTO followersPageQueryDTO) {
+        PageResult followersList = userService.getFollowers(followersPageQueryDTO);
+        return RestResult.success(followersList);
     }
 
     /**
      * 查询关注列表
      * */
-    @GetMapping("/follows/following/{id}")
-    @ApiOperation("查询关注列表")
+    @GetMapping("/follows/following")
+    @ApiOperation("分页查询给定id的关注列表")
     @CheckAuth(check = false)
-    public RestResult<FollowingsDTO> getFollowings(@ApiParam("查询用户id") @PathVariable Long id) {
-        List<Follows> followsList = userService.getFollowings(id);
-        List<Long> follwingsList = followsList.stream().map(Follows::getFollowingId).collect(Collectors.toList());
-        FollowingsDTO followingsDTO = new FollowingsDTO().builder()
-                .id(id)
-                .followingIds(follwingsList)
-                .build();
-        return RestResult.success(followingsDTO);
+    public RestResult<PageResult> getFollowings(FollowingsPageQueryDTO followingsPageQueryDTO) {
+        PageResult followingsPageList = userService.getFollowings(followingsPageQueryDTO);
+        return RestResult.success(followingsPageList);
     }
 
     /**
@@ -268,16 +259,11 @@ public class UserController {
      * 查询点赞视频
      * */
     @GetMapping("/likes")
-    @ApiOperation("查询点赞视频")
-    public RestResult<LikeVideosDTO> getLikeVideos() {
+    @ApiOperation("分页查询点赞视频")
+    public RestResult<PageResult> getLikeVideos(LikesPageQueryDTO likesPageQueryDTO) {
         Long userId = BaseContext.getCurrentUserId();
-        List<Likes> likes = userService.getLikes(userId);
-        List<Long> videoIds = likes.stream().map(Likes::getVideoId).collect(Collectors.toList());
-        LikeVideosDTO likeVideosDTO = new LikeVideosDTO().builder()
-                .userId(userId)
-                .videoIds(videoIds)
-                .build();
-        return RestResult.success(likeVideosDTO);
+        PageResult likesList = userService.getLikes(userId, likesPageQueryDTO);
+        return RestResult.success(likesList);
     }
 
     @GetMapping("/creates")

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/controller/VideoController.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/controller/VideoController.java
@@ -18,6 +18,7 @@ import org.zjudevelop.playerbackbend.service.UploadService;
 import org.zjudevelop.playerbackbend.service.UserService;
 import org.zjudevelop.playerbackbend.service.VideoService;
 import org.zjudevelop.playerbackbend.utils.JwtUtil;
+import org.zjudevelop.playerbackbend.utils.PageResult;
 import org.zjudevelop.playerbackbend.utils.RestResult;
 import org.zjudevelop.playerbackbend.utils.FileProcessUtil;
 import org.zjudevelop.playerbackbend.utils.VideoProcessUtil;
@@ -133,5 +134,18 @@ public class VideoController {
         return currentUserId;
     }
 
+    /**
+     * 分页获取视频
+     * @param videosPageQueryDTO
+     * @return org.zjudevelop.playerbackbend.utils.RestResult<org.zjudevelop.playerbackbend.utils.PageResult>
+     * */
+    @GetMapping
+    @ApiOperation("分页获取视频")
+    @CheckAuth(check = false)
+    public RestResult<PageResult> getVideos(VideosPageQueryDTO videosPageQueryDTO) {
+        // TODO: 打乱后，再分页取
+        PageResult videoList = videoService.getVideos(videosPageQueryDTO);
+        return RestResult.success(videoList);
+    }
 
 }

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/FollowersPageQueryDTO.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/FollowersPageQueryDTO.java
@@ -1,0 +1,27 @@
+package org.zjudevelop.playerbackbend.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FollowersPageQueryDTO implements Serializable {
+
+    @ApiModelProperty(value = "用户id", required = true)
+    private Long id;
+
+    @ApiModelProperty(value = "页数", required = true)
+    private int page;
+
+    @ApiModelProperty(value = "每页大小", required = true)
+    private int pageSize;
+}

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/FollowingsPageQueryDTO.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/FollowingsPageQueryDTO.java
@@ -1,0 +1,26 @@
+package org.zjudevelop.playerbackbend.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FollowingsPageQueryDTO implements Serializable {
+
+    @ApiModelProperty(value = "用户id", required = true)
+    private Long id;
+
+    @ApiModelProperty(value = "页数", required = true)
+    private int page;
+
+    @ApiModelProperty(value = "每页大小", required = true)
+    private int pageSize;
+}

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/LikesPageQueryDTO.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/LikesPageQueryDTO.java
@@ -1,0 +1,19 @@
+package org.zjudevelop.playerbackbend.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LikesPageQueryDTO {
+    @ApiModelProperty(value = "页数", required = true)
+    private int page;
+
+    @ApiModelProperty(value = "每页大小", required = true)
+    private int pageSize;
+}

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/VideosPageQueryDTO.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/dto/VideosPageQueryDTO.java
@@ -1,0 +1,19 @@
+package org.zjudevelop.playerbackbend.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class VideosPageQueryDTO {
+    @ApiModelProperty(value = "页数", required = true)
+    private int page;
+
+    @ApiModelProperty(value = "每页大小", required = true)
+    private int pageSize;
+}

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/UserService.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/UserService.java
@@ -3,10 +3,9 @@ package org.zjudevelop.playerbackbend.service;
 import org.zjudevelop.playerbackbend.domain.Creates;
 import org.zjudevelop.playerbackbend.domain.Follows;
 import org.zjudevelop.playerbackbend.domain.Likes;
-import org.zjudevelop.playerbackbend.dto.UserLoginDTO;
-import org.zjudevelop.playerbackbend.dto.UserRegisterDTO;
+import org.zjudevelop.playerbackbend.dto.*;
 import org.zjudevelop.playerbackbend.domain.User;
-import org.zjudevelop.playerbackbend.dto.VideoInfoDTO;
+import org.zjudevelop.playerbackbend.utils.PageResult;
 
 import java.util.List;
 
@@ -25,6 +24,8 @@ public interface UserService {
 
     List<Likes> getLikes(Long userId);
 
+    PageResult getLikes(Long userId, LikesPageQueryDTO likesPageQueryDTO);
+
     int follow(Follows follows);
 
     int create(Creates creates);
@@ -33,9 +34,9 @@ public interface UserService {
 
     int unfollow(Follows follows);
 
-    List<Follows> getFollowings(Long userId);
+    PageResult getFollowings(FollowingsPageQueryDTO followingsPageQueryDTO);
 
-    List<Follows> getFollowers(Long userId);
+    PageResult getFollowers(FollowersPageQueryDTO followersPageQueryDTO);
 
     List<VideoInfoDTO> getOwnVideosById(Long userId);
 

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/VideoService.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/VideoService.java
@@ -1,10 +1,8 @@
 package org.zjudevelop.playerbackbend.service;
 
 import org.zjudevelop.playerbackbend.domain.User;
-import org.zjudevelop.playerbackbend.dto.UserInfoDTO;
-import org.zjudevelop.playerbackbend.dto.VideoInfoDTO;
-import org.zjudevelop.playerbackbend.dto.VideoInsertDTO;
-import org.zjudevelop.playerbackbend.dto.VideoSearchInfoDTO;
+import org.zjudevelop.playerbackbend.dto.*;
+import org.zjudevelop.playerbackbend.utils.PageResult;
 
 import java.util.List;
 
@@ -21,4 +19,6 @@ public interface VideoService {
     List<VideoSearchInfoDTO> getVideoInfoByKeyword(String keyword);
 
     UserInfoDTO getCreaterInfoById(Long videoId);
+
+    PageResult getVideos(VideosPageQueryDTO videosPageQueryDTO);
 }

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/impl/VideoServiceImpl.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/service/impl/VideoServiceImpl.java
@@ -1,6 +1,7 @@
 package org.zjudevelop.playerbackbend.service.impl;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -8,16 +9,11 @@ import org.zjudevelop.playerbackbend.dao.CategoryMapper;
 import org.zjudevelop.playerbackbend.dao.CreatesMapper;
 import org.zjudevelop.playerbackbend.dao.UserMapper;
 import org.zjudevelop.playerbackbend.dao.VideoMapper;
-import org.zjudevelop.playerbackbend.domain.CategoryPO;
-import org.zjudevelop.playerbackbend.domain.Creates;
-import org.zjudevelop.playerbackbend.domain.User;
-import org.zjudevelop.playerbackbend.domain.VideoPO;
-import org.zjudevelop.playerbackbend.dto.UserInfoDTO;
-import org.zjudevelop.playerbackbend.dto.VideoInsertDTO;
-import org.zjudevelop.playerbackbend.dto.VideoInfoDTO;
-import org.zjudevelop.playerbackbend.dto.VideoSearchInfoDTO;
+import org.zjudevelop.playerbackbend.domain.*;
+import org.zjudevelop.playerbackbend.dto.*;
 import org.zjudevelop.playerbackbend.service.VideoService;
 import org.zjudevelop.playerbackbend.utils.DTOUtil;
+import org.zjudevelop.playerbackbend.utils.PageResult;
 
 
 import java.util.ArrayList;
@@ -116,5 +112,12 @@ public class VideoServiceImpl implements VideoService {
         User user = userMapper.selectById(creates.getUserId());
 
         return DTOUtil.makeUserInfoDTO(user);
+    }
+
+    @Override
+    public PageResult getVideos(VideosPageQueryDTO videosPageQueryDTO) {
+        Page<VideoPO> page = new Page<>(videosPageQueryDTO.getPage(), videosPageQueryDTO.getPageSize());
+        Page<VideoPO> pageResult = videoMapper.selectPage(page, null);
+        return new PageResult(pageResult.getTotal(), pageResult.getRecords());
     }
 }

--- a/player-backbend/src/main/java/org/zjudevelop/playerbackbend/utils/PageResult.java
+++ b/player-backbend/src/main/java/org/zjudevelop/playerbackbend/utils/PageResult.java
@@ -1,0 +1,22 @@
+package org.zjudevelop.playerbackbend.utils;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResult implements Serializable {
+
+    @ApiModelProperty(value = "查询结果总数量")
+    private long total;
+
+    @ApiModelProperty(value = "查询结果")
+    private List records;
+
+}


### PR DESCRIPTION
# 新增功能
1. 添加以下查询的分页查询功能：视频查询、关注列表查询、粉丝列表查询、点赞列表查询

# 测试结果
- 视频查询测试：
![image](https://github.com/Sparkle6979/VideoPlayer/assets/133086269/7cd43e99-c6f8-43da-a4ed-73dd10d6fe7b)
- 关注列表查询：
![image](https://github.com/Sparkle6979/VideoPlayer/assets/133086269/97ec5f11-0756-4579-b00e-abfc1cb91ca2)
- 粉丝列表查询：
![image](https://github.com/Sparkle6979/VideoPlayer/assets/133086269/7d76ec44-059e-4085-bdfb-954ee442107a)
- 点赞视频列表查询：
![image](https://github.com/Sparkle6979/VideoPlayer/assets/133086269/534e36d8-b2b1-46a9-8f57-65cc25a5b324)
